### PR TITLE
Resolved - Build Failure with Node.js v18.18.0 Due to SSL Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"scripts": {
 		"start": "set PORT=6366 && react-scripts --openssl-legacy-provider start",
-		"build": "yarn run react-scripts build",
+		"build": "react-scripts --openssl-legacy-provider build",
 		"test": "react-scripts test",
 		"eject": "react-scripts eject",
 		"build:css": "postcss src/css/tailwind.css -o src/css/main.css"


### PR DESCRIPTION
### Issue Title: Resolved - Build Failure with Node.js v18.18.0 Due to SSL Error

### Resolution Summary:
The build failure issue, which was occurring due to an SSL-related error with Node.js v18.18.0, has been resolved by modifying the `build` script in the `package.json` file.

### Implemented Solution:
Changed the `build` script in `package.json` to utilize the `--openssl-legacy-provider` flag with `react-scripts`:
```json
"scripts": {
    "build": "react-scripts --openssl-legacy-provider build",
    ...
}
```

### Explanation:
The `--openssl-legacy-provider` flag ensures that Node.js uses the legacy provider for OpenSSL, mitigating the SSL-related error (`ERR_OSSL_EVP_UNSUPPORTED`) encountered during the build process.

### Verification:
After implementing the change, running `yarn build` successfully builds the project without throwing the SSL error.

### Additional Notes:
- This solution ensures compatibility with Node.js v18.18.0 without downgrading or altering SSL dependencies.
- Ensure to test the build in various environments to confirm the consistency of the solution.

### Attachments:
- [Updated package.json](link-to-updated-package.json-if-available)